### PR TITLE
Revert incorrect removal of mut qualifier on recv variable

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -92,7 +92,7 @@ pub async fn run_client(connection_string: String) -> Result<()> {
     println!("Press Ctrl+D to disconnect.");
 
     // Open a bidirectional QUIC stream
-    let (mut send, recv) = conn.open_bi().await.e()?;
+    let (mut send, mut recv) = conn.open_bi().await.e()?;
 
     // Send Hello message to indicate this is a shell session
     let config = config::standard();


### PR DESCRIPTION
The recv variable needs to be mutable because it's used in a closure where read_exact() is called, which requires a mutable reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)