### PR TITLE
Fix race condition causing client to hang after typing 'exit'

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -508,9 +508,10 @@ impl KerrServer {
             }
         }
 
-        // Clean up
-        pty_to_client.abort();
-        send_task.abort();
+        // Clean up - ensure all queued messages are sent before closing
+        pty_to_client.abort(); // PTY task should already be done, but ensure it's aborted
+        drop(send_tx); // Close the send channel so send_task knows to finish
+        let _ = send_task.await; // Wait for send_task to finish sending all queued messages
         println!("\r\nConnection closed for {node_id}\r");
 
         Ok(())


### PR DESCRIPTION
When bash exits, the server sends an Error message to notify the client, but was immediately aborting the send_task before the message could be sent. This caused the client to never receive the disconnect notification and hang indefinitely, requiring manual Ctrl+D to disconnect.

The fix ensures all queued messages are sent before cleanup:
1. Abort the PTY task (already done, but ensures cleanup)
2. Drop the send_tx channel to signal no more messages
3. Await send_task completion to flush all queued messages
4. Then close the connection

This makes 'kerr connect' behave like SSH, automatically disconnecting when the remote bash process exits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)