### PR TITLE
Add systemd service installer and fix headless serve mode

### DIFF
--- a/scripts/install-service.sh
+++ b/scripts/install-service.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# install-service.sh — Register `kerr serve` as a systemd user service.
+#
+# Prerequisites:
+#   1. Run `kerr login` at least once so a session exists.
+#   2. Either pass --name <alias> OR create the autostart config file:
+#        ~/.config/kerr/autostart.json  →  { "register": "your-alias" }
+#
+# Usage:
+#   ./scripts/install-service.sh [--name <alias>] [--binary <path>]
+#   ./scripts/install-service.sh --help
+
+set -euo pipefail
+
+# ── Config paths ───────────────────────────────────────────────────────────────
+KERR_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/kerr"
+SESSION_FILE="$KERR_CONFIG_DIR/session.json"
+AUTOSTART_CONFIG="$KERR_CONFIG_DIR/autostart.json"
+SYSTEMD_USER_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+SERVICE_FILE="$SYSTEMD_USER_DIR/kerr.service"
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+die()  { echo "Error: $*" >&2; exit 1; }
+info() { echo "  $*"; }
+
+json_field() {
+    # json_field <file> <key>  — extract a top-level string value without jq
+    local file="$1" key="$2" value=""
+    if command -v python3 >/dev/null 2>&1; then
+        value=$(python3 - "$file" "$key" <<'PYEOF'
+import json, sys
+try:
+    data = json.load(open(sys.argv[1]))
+    print(data.get(sys.argv[2], ""))
+except Exception:
+    print("")
+PYEOF
+        )
+    else
+        # Fallback: basic grep-based extraction (no nested objects)
+        value=$(grep -oE "\"${key}\"[[:space:]]*:[[:space:]]*\"[^\"]+\"" "$file" \
+            | sed 's/.*":\s*"\(.*\)"/\1/' 2>/dev/null || true)
+    fi
+    printf '%s' "$value"
+}
+
+# ── Parse arguments ────────────────────────────────────────────────────────────
+REGISTER_NAME=""
+KERR_BIN_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --name)
+            [[ $# -ge 2 ]] || die "--name requires an argument."
+            REGISTER_NAME="$2"; shift 2;;
+        --name=*)
+            REGISTER_NAME="${1#--name=}"; shift;;
+        --binary)
+            [[ $# -ge 2 ]] || die "--binary requires an argument."
+            KERR_BIN_OVERRIDE="$2"; shift 2;;
+        --binary=*)
+            KERR_BIN_OVERRIDE="${1#--binary=}"; shift;;
+        -h|--help)
+            cat <<'HELP'
+Usage: install-service.sh [OPTIONS]
+
+Register 'kerr serve --register <alias>' as a systemd user service that
+auto-starts on machine boot.
+
+Prerequisites:
+  1. Run 'kerr login' first to create a valid session.
+  2. Provide the registration alias via --name or in the autostart config:
+       ~/.config/kerr/autostart.json
+     Contents: { "register": "your-alias" }
+
+Options:
+  --name <alias>   Registration alias passed to 'kerr serve --register'.
+                   Takes precedence over the autostart config file.
+  --binary <path>  Path to the kerr binary (auto-detected if not set).
+  -h, --help       Show this help message.
+
+After installation:
+  Status  : systemctl --user status kerr
+  Logs    : journalctl --user -u kerr -f
+  Stop    : systemctl --user stop kerr
+  Disable : systemctl --user disable kerr
+  Remove  : ./scripts/uninstall-service.sh
+HELP
+            exit 0;;
+        *)
+            die "Unknown argument: '$1'. Run with --help for usage.";;
+    esac
+done
+
+# ── Preflight: systemd ─────────────────────────────────────────────────────────
+command -v systemctl >/dev/null 2>&1 \
+    || die "systemd is not available on this system. Cannot install a service."
+
+# ── Preflight: kerr binary ─────────────────────────────────────────────────────
+if [[ -n "$KERR_BIN_OVERRIDE" ]]; then
+    KERR_BIN="$KERR_BIN_OVERRIDE"
+    [[ -x "$KERR_BIN" ]] \
+        || die "Specified binary is not executable: $KERR_BIN"
+else
+    KERR_BIN=""
+    for candidate in \
+        "$(command -v kerr 2>/dev/null || true)" \
+        "$HOME/.cargo/bin/kerr" \
+        "$HOME/.local/bin/kerr" \
+        "/usr/local/bin/kerr"; do
+        if [[ -n "$candidate" && -x "$candidate" ]]; then
+            KERR_BIN="$candidate"
+            break
+        fi
+    done
+    [[ -n "$KERR_BIN" ]] \
+        || die "Cannot find 'kerr' binary. Build it, install it, or pass --binary <path>."
+fi
+
+# ── Preflight: user login ──────────────────────────────────────────────────────
+[[ -f "$SESSION_FILE" ]] \
+    || die "Not logged in. Run 'kerr login' first, then re-run this script."
+
+SESSION_ID="$(json_field "$SESSION_FILE" "session_id")"
+[[ -n "$SESSION_ID" ]] \
+    || die "Session file exists but has no valid session_id. Run 'kerr login' again."
+
+# ── Resolve registration alias ─────────────────────────────────────────────────
+if [[ -z "$REGISTER_NAME" ]]; then
+    if [[ ! -f "$AUTOSTART_CONFIG" ]]; then
+        die "No registration alias provided and no autostart config found.
+       Either:
+         1. Pass:  --name <your-alias>
+         2. Create $AUTOSTART_CONFIG with:
+              { \"register\": \"your-alias\" }"
+    fi
+
+    REGISTER_NAME="$(json_field "$AUTOSTART_CONFIG" "register")"
+    [[ -n "$REGISTER_NAME" ]] \
+        || die "Key 'register' is missing or empty in $AUTOSTART_CONFIG"
+fi
+
+# ── Write systemd unit file ────────────────────────────────────────────────────
+mkdir -p "$SYSTEMD_USER_DIR"
+
+cat > "$SERVICE_FILE" <<UNIT
+[Unit]
+Description=Kerr P2P Remote Shell Server
+Documentation=https://github.com/shi-yan/kerr
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=$KERR_BIN serve --register $REGISTER_NAME
+Restart=on-failure
+RestartSec=5s
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target
+UNIT
+
+info "Service file written: $SERVICE_FILE"
+
+# ── Enable linger so service starts at boot, not just on login ─────────────────
+if loginctl enable-linger "$(id -un)" 2>/dev/null; then
+    info "Linger enabled for user '$(id -un)' — service will start at boot."
+else
+    echo ""
+    echo "Warning: Could not enable linger. The service will only start when you log in,"
+    echo "         not automatically at machine boot."
+    echo "         To fix: sudo loginctl enable-linger $(id -un)"
+fi
+
+# ── Activate the service ───────────────────────────────────────────────────────
+systemctl --user daemon-reload
+systemctl --user enable kerr.service
+systemctl --user start  kerr.service
+
+echo ""
+echo "Kerr service installed and started."
+echo "  Alias   : $REGISTER_NAME"
+echo "  Binary  : $KERR_BIN"
+echo "  Status  : systemctl --user status kerr"
+echo "  Logs    : journalctl --user -u kerr -f"
+echo "  Stop    : systemctl --user stop kerr"
+echo "  Remove  : $(dirname "$0")/uninstall-service.sh"

--- a/scripts/install-service.sh
+++ b/scripts/install-service.sh
@@ -9,8 +9,15 @@
 # Usage:
 #   ./scripts/install-service.sh [--name <alias>] [--from local|github] [--binary <path>]
 #   ./scripts/install-service.sh --help
+#
+# Rerunning this script updates the service: the binary is re-resolved, the
+# unit file is overwritten, and a running service is restarted in-place.
 
 set -euo pipefail
+
+# ── Locate repo root (script lives in <repo>/scripts/) ────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # ── Constants ──────────────────────────────────────────────────────────────────
 GITHUB_REPO="https://github.com/shi-yan/kerr"
@@ -93,11 +100,14 @@ Prerequisites:
      Contents: { "register": "your-alias" }
 
 Options:
-  --from local      Use an already-installed kerr binary (default).
-                    Searches PATH, ~/.cargo/bin, ~/.local/bin, /usr/local/bin.
-  --from github     Install kerr from GitHub before setting up the service:
+  --from local      Use the local build from the repo (default).
+                    Search order: target/release/kerr → target/debug/kerr →
+                    PATH → ~/.cargo/bin → ~/.local/bin → /usr/local/bin.
+                    Rerun after `cargo build --release` to update the service.
+  --from github     Install from GitHub then set up the service:
                       cargo install --git https://github.com/shi-yan/kerr
                     Requires cargo (install via https://rustup.rs).
+                    Rerun to upgrade to the latest commit on the default branch.
   --name <alias>    Registration alias passed to 'kerr serve --register'.
                     Takes precedence over the autostart config file.
   --binary <path>   Explicit path to the kerr binary. Skips binary search and
@@ -141,9 +151,12 @@ elif [[ "$INSTALL_FROM" == "github" ]]; then
     info "Installed: $KERR_BIN"
 
 else
-    # local: search PATH and common install locations.
+    # local: prefer the repo's own build artifacts, then fall back to system
+    # locations for cases where kerr was installed separately.
     KERR_BIN=""
     for candidate in \
+        "$REPO_ROOT/target/release/kerr" \
+        "$REPO_ROOT/target/debug/kerr" \
         "$(command -v kerr 2>/dev/null || true)" \
         "${CARGO_HOME:-$HOME/.cargo}/bin/kerr" \
         "$HOME/.local/bin/kerr" \
@@ -154,7 +167,7 @@ else
         fi
     done
     [[ -n "$KERR_BIN" ]] \
-        || die "Cannot find 'kerr' binary. Build and install it, or use --from github."
+        || die "No kerr binary found. Run 'cargo build --release' first, or use --from github."
 fi
 
 # ── Preflight: user login ──────────────────────────────────────────────────────
@@ -215,13 +228,19 @@ else
     echo "         To fix: sudo loginctl enable-linger $(id -un)"
 fi
 
-# ── Activate the service ───────────────────────────────────────────────────────
+# ── Activate the service (restart if already running, start if fresh) ──────────
 systemctl --user daemon-reload
 systemctl --user enable kerr.service
-systemctl --user start  kerr.service
+if systemctl --user is-active --quiet kerr.service 2>/dev/null; then
+    systemctl --user restart kerr.service
+    ACTIVATED="restarted"
+else
+    systemctl --user start kerr.service
+    ACTIVATED="started"
+fi
 
 echo ""
-echo "Kerr service installed and started."
+echo "Kerr service installed and $ACTIVATED."
 echo "  Alias      : $REGISTER_NAME"
 echo "  Binary     : $KERR_BIN"
 echo "  Log file   : $KERR_LOG_FILE"

--- a/scripts/install-service.sh
+++ b/scripts/install-service.sh
@@ -7,10 +7,13 @@
 #        ~/.config/kerr/autostart.json  →  { "register": "your-alias" }
 #
 # Usage:
-#   ./scripts/install-service.sh [--name <alias>] [--binary <path>]
+#   ./scripts/install-service.sh [--name <alias>] [--from local|github] [--binary <path>]
 #   ./scripts/install-service.sh --help
 
 set -euo pipefail
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+GITHUB_REPO="https://github.com/shi-yan/kerr"
 
 # ── Config paths ───────────────────────────────────────────────────────────────
 KERR_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/kerr"
@@ -52,6 +55,7 @@ PYEOF
 
 # ── Parse arguments ────────────────────────────────────────────────────────────
 REGISTER_NAME=""
+INSTALL_FROM="local"   # local | github
 KERR_BIN_OVERRIDE=""
 
 while [[ $# -gt 0 ]]; do
@@ -61,6 +65,15 @@ while [[ $# -gt 0 ]]; do
             REGISTER_NAME="$2"; shift 2;;
         --name=*)
             REGISTER_NAME="${1#--name=}"; shift;;
+        --from)
+            [[ $# -ge 2 ]] || die "--from requires an argument: local or github."
+            INSTALL_FROM="$2"; shift 2
+            [[ "$INSTALL_FROM" == "local" || "$INSTALL_FROM" == "github" ]] \
+                || die "--from must be 'local' or 'github', got '$INSTALL_FROM'.";;
+        --from=*)
+            INSTALL_FROM="${1#--from=}"; shift
+            [[ "$INSTALL_FROM" == "local" || "$INSTALL_FROM" == "github" ]] \
+                || die "--from must be 'local' or 'github', got '$INSTALL_FROM'.";;
         --binary)
             [[ $# -ge 2 ]] || die "--binary requires an argument."
             KERR_BIN_OVERRIDE="$2"; shift 2;;
@@ -80,10 +93,16 @@ Prerequisites:
      Contents: { "register": "your-alias" }
 
 Options:
-  --name <alias>   Registration alias passed to 'kerr serve --register'.
-                   Takes precedence over the autostart config file.
-  --binary <path>  Path to the kerr binary (auto-detected if not set).
-  -h, --help       Show this help message.
+  --from local      Use an already-installed kerr binary (default).
+                    Searches PATH, ~/.cargo/bin, ~/.local/bin, /usr/local/bin.
+  --from github     Install kerr from GitHub before setting up the service:
+                      cargo install --git https://github.com/shi-yan/kerr
+                    Requires cargo (install via https://rustup.rs).
+  --name <alias>    Registration alias passed to 'kerr serve --register'.
+                    Takes precedence over the autostart config file.
+  --binary <path>   Explicit path to the kerr binary. Skips binary search and
+                    --from logic entirely.
+  -h, --help        Show this help message.
 
 After installation:
   Status     : systemctl --user status kerr
@@ -103,16 +122,30 @@ done
 command -v systemctl >/dev/null 2>&1 \
     || die "systemd is not available on this system. Cannot install a service."
 
-# ── Preflight: kerr binary ─────────────────────────────────────────────────────
+# ── Resolve kerr binary ────────────────────────────────────────────────────────
 if [[ -n "$KERR_BIN_OVERRIDE" ]]; then
+    # Explicit path always wins, regardless of --from.
     KERR_BIN="$KERR_BIN_OVERRIDE"
     [[ -x "$KERR_BIN" ]] \
         || die "Specified binary is not executable: $KERR_BIN"
+
+elif [[ "$INSTALL_FROM" == "github" ]]; then
+    command -v cargo >/dev/null 2>&1 \
+        || die "cargo is required for --from github but was not found in PATH.
+       Install Rust/cargo: https://rustup.rs"
+    echo "Installing kerr from GitHub ($GITHUB_REPO)..."
+    cargo install --git "$GITHUB_REPO" --locked
+    KERR_BIN="${CARGO_HOME:-$HOME/.cargo}/bin/kerr"
+    [[ -x "$KERR_BIN" ]] \
+        || die "cargo install appeared to succeed but binary not found at $KERR_BIN"
+    info "Installed: $KERR_BIN"
+
 else
+    # local: search PATH and common install locations.
     KERR_BIN=""
     for candidate in \
         "$(command -v kerr 2>/dev/null || true)" \
-        "$HOME/.cargo/bin/kerr" \
+        "${CARGO_HOME:-$HOME/.cargo}/bin/kerr" \
         "$HOME/.local/bin/kerr" \
         "/usr/local/bin/kerr"; do
         if [[ -n "$candidate" && -x "$candidate" ]]; then
@@ -121,7 +154,7 @@ else
         fi
     done
     [[ -n "$KERR_BIN" ]] \
-        || die "Cannot find 'kerr' binary. Build it, install it, or pass --binary <path>."
+        || die "Cannot find 'kerr' binary. Build and install it, or use --from github."
 fi
 
 # ── Preflight: user login ──────────────────────────────────────────────────────

--- a/scripts/install-service.sh
+++ b/scripts/install-service.sh
@@ -170,6 +170,13 @@ else
         || die "No kerr binary found. Run 'cargo build --release' first, or use --from github."
 fi
 
+# Normalise to an absolute, symlink-resolved path so the unit file and the
+# printed summary always show exactly what systemd will execute.
+KERR_BIN="$(realpath "$KERR_BIN" 2>/dev/null \
+    || readlink -f "$KERR_BIN" 2>/dev/null \
+    || echo "$KERR_BIN")"
+info "Binary resolved    : $KERR_BIN"
+
 # ── Preflight: user login ──────────────────────────────────────────────────────
 [[ -f "$SESSION_FILE" ]] \
     || die "Not logged in. Run 'kerr login' first, then re-run this script."

--- a/scripts/install-service.sh
+++ b/scripts/install-service.sh
@@ -19,6 +19,12 @@ AUTOSTART_CONFIG="$KERR_CONFIG_DIR/autostart.json"
 SYSTEMD_USER_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
 SERVICE_FILE="$SYSTEMD_USER_DIR/kerr.service"
 
+# XDG state dir is the correct location for persistent log files from a user
+# service (as opposed to XDG_CONFIG_HOME for config or XDG_CACHE_HOME for
+# transient data).  Falls back to ~/.local/state when XDG_STATE_HOME is unset.
+KERR_LOG_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/kerr"
+KERR_LOG_FILE="$KERR_LOG_DIR/server.log"
+
 # ── Helpers ────────────────────────────────────────────────────────────────────
 die()  { echo "Error: $*" >&2; exit 1; }
 info() { echo "  $*"; }
@@ -80,11 +86,12 @@ Options:
   -h, --help       Show this help message.
 
 After installation:
-  Status  : systemctl --user status kerr
-  Logs    : journalctl --user -u kerr -f
-  Stop    : systemctl --user stop kerr
-  Disable : systemctl --user disable kerr
-  Remove  : ./scripts/uninstall-service.sh
+  Status     : systemctl --user status kerr
+  Live logs  : journalctl --user -u kerr -f
+  Log file   : ~/.local/state/kerr/server.log  (or $XDG_STATE_HOME/kerr/)
+  Stop       : systemctl --user stop kerr
+  Disable    : systemctl --user disable kerr
+  Remove     : ./scripts/uninstall-service.sh
 HELP
             exit 0;;
         *)
@@ -142,6 +149,7 @@ fi
 
 # ── Write systemd unit file ────────────────────────────────────────────────────
 mkdir -p "$SYSTEMD_USER_DIR"
+mkdir -p "$KERR_LOG_DIR"
 
 cat > "$SERVICE_FILE" <<UNIT
 [Unit]
@@ -151,7 +159,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-ExecStart=$KERR_BIN serve --register $REGISTER_NAME
+ExecStart=$KERR_BIN serve --register $REGISTER_NAME --log $KERR_LOG_FILE
 Restart=on-failure
 RestartSec=5s
 StandardOutput=journal
@@ -162,6 +170,7 @@ WantedBy=default.target
 UNIT
 
 info "Service file written: $SERVICE_FILE"
+info "Log file location  : $KERR_LOG_FILE"
 
 # ── Enable linger so service starts at boot, not just on login ─────────────────
 if loginctl enable-linger "$(id -un)" 2>/dev/null; then
@@ -180,9 +189,11 @@ systemctl --user start  kerr.service
 
 echo ""
 echo "Kerr service installed and started."
-echo "  Alias   : $REGISTER_NAME"
-echo "  Binary  : $KERR_BIN"
-echo "  Status  : systemctl --user status kerr"
-echo "  Logs    : journalctl --user -u kerr -f"
-echo "  Stop    : systemctl --user stop kerr"
-echo "  Remove  : $(dirname "$0")/uninstall-service.sh"
+echo "  Alias      : $REGISTER_NAME"
+echo "  Binary     : $KERR_BIN"
+echo "  Log file   : $KERR_LOG_FILE"
+echo "  Status     : systemctl --user status kerr"
+echo "  Live logs  : journalctl --user -u kerr -f"
+echo "  Log file   : tail -f $KERR_LOG_FILE"
+echo "  Stop       : systemctl --user stop kerr"
+echo "  Remove     : $(dirname "$0")/uninstall-service.sh"

--- a/scripts/uninstall-service.sh
+++ b/scripts/uninstall-service.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# uninstall-service.sh — Stop and remove the Kerr systemd user service.
+#
+# Usage: ./scripts/uninstall-service.sh
+
+set -euo pipefail
+
+SYSTEMD_USER_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+SERVICE_FILE="$SYSTEMD_USER_DIR/kerr.service"
+
+die() { echo "Error: $*" >&2; exit 1; }
+
+command -v systemctl >/dev/null 2>&1 \
+    || die "systemd is not available on this system."
+
+echo "Stopping and disabling Kerr service..."
+
+systemctl --user stop    kerr.service 2>/dev/null || true
+systemctl --user disable kerr.service 2>/dev/null || true
+
+if [[ -f "$SERVICE_FILE" ]]; then
+    rm "$SERVICE_FILE"
+    echo "  Removed: $SERVICE_FILE"
+else
+    echo "  Service file not found (already removed?)."
+fi
+
+systemctl --user daemon-reload
+
+echo ""
+echo "Kerr service removed."
+echo "Note: Your login session (~/.config/kerr/session.json) was not modified."

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -3,12 +3,12 @@
 //! Provides structured logging with file output, timestamps, and user context
 
 use anyhow::Result;
-use std::fs::OpenOptions;
-use std::io::Write;
+use std::fs::{self, OpenOptions};
+use std::io::{IsTerminal, Write};
 use std::path::Path;
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
-/// A writer that converts \n to \r\n for proper terminal display
+/// A writer that converts \n to \r\n for proper terminal display in raw mode
 struct CrLfWriter<W: Write> {
     inner: W,
 }
@@ -21,7 +21,6 @@ impl<W: Write> CrLfWriter<W> {
 
 impl<W: Write> Write for CrLfWriter<W> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        // Convert \n to \r\n
         let mut output = Vec::new();
         for &byte in buf {
             if byte == b'\n' {
@@ -40,36 +39,38 @@ impl<W: Write> Write for CrLfWriter<W> {
     }
 }
 
-/// Initialize logging for the kerr server
+/// Initialize logging for the kerr server.
 ///
-/// Sets up tracing to write to the specified log file with:
-/// - Timestamps for each log entry
-/// - User information (username)
-/// - Append mode (doesn't overwrite existing logs)
-/// - Structured log format
+/// Logs to the given file (append mode) and also to stderr.
+/// When stderr is a TTY (interactive terminal), `\n` is converted to `\r\n`
+/// so output is correct under crossterm raw mode. When stderr is not a TTY
+/// (e.g. a systemd service piping to journald), plain line endings are used
+/// so journald does not record spurious blank lines.
 ///
-/// Returns a guard that must be kept alive for the duration of the program
+/// Returns a guard that must be kept alive for the duration of the program.
 pub fn init_server_logging<P: AsRef<Path>>(log_file: P) -> Result<tracing_appender::non_blocking::WorkerGuard> {
     let log_path = log_file.as_ref();
+
+    // Ensure the log directory exists before we try to open/create the file.
+    if let Some(parent) = log_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
 
     // Get current user information
     let username = std::env::var("USER")
         .or_else(|_| std::env::var("USERNAME"))
         .unwrap_or_else(|_| "unknown".to_string());
-
-    let is_root = username == "root" || std::env::var("USER").map(|u| u == "root").unwrap_or(false);
+    let is_root = username == "root";
     let user_info = if is_root {
-        format!("USER=root (privileged)")
+        "USER=root (privileged)".to_string()
     } else {
         format!("USER={}", username)
     };
 
-    // Write initial log header to file (append mode)
-    if let Ok(mut file) = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(log_path)
-    {
+    // Write session header (append mode — never overwrites prior runs)
+    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(log_path) {
         let timestamp = chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
         let separator = "=".repeat(80);
         writeln!(file, "\n{}", separator)?;
@@ -80,41 +81,50 @@ pub fn init_server_logging<P: AsRef<Path>>(log_file: P) -> Result<tracing_append
         file.flush()?;
     }
 
-    // Create file appender for tracing
-    let file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(log_path)?;
-
-    // IMPORTANT: Keep the guard alive! When it's dropped, logging stops.
+    let file = OpenOptions::new().create(true).append(true).open(log_path)?;
     let (file_writer, guard) = tracing_appender::non_blocking(file);
 
-    // Set up the tracing subscriber with file output
     let file_layer = fmt::layer()
         .with_writer(file_writer)
-        .with_ansi(false) // No ANSI colors in log file
+        .with_ansi(false)
         .with_target(true)
         .with_thread_ids(false)
         .with_line_number(false);
 
-    // Also output to stderr for interactive use
-    // Wrap stderr with CrLfWriter to convert \n to \r\n for proper terminal display
-    let stderr_layer = fmt::layer()
-        .with_writer(|| CrLfWriter::new(std::io::stderr()))
-        .with_ansi(true)
-        .with_target(false)
-        .with_thread_ids(false)
-        .with_line_number(false);
-
-    // Set up env filter (can be controlled via RUST_LOG env var)
     let env_filter = EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| EnvFilter::new("info"));
 
-    tracing_subscriber::registry()
-        .with(env_filter)
-        .with(file_layer)
-        .with(stderr_layer)
-        .init();
+    // When stderr is a TTY (interactive), raw mode is active so \n alone does
+    // not move the cursor to column 0 — we need \r\n.  When stderr goes to
+    // journald or a pipe, plain \n is correct; CrLfWriter would produce blank
+    // lines between every tracing record in `journalctl`.
+    if std::io::stderr().is_terminal() {
+        tracing_subscriber::registry()
+            .with(env_filter)
+            .with(file_layer)
+            .with(
+                fmt::layer()
+                    .with_writer(|| CrLfWriter::new(std::io::stderr()))
+                    .with_ansi(true)
+                    .with_target(false)
+                    .with_thread_ids(false)
+                    .with_line_number(false),
+            )
+            .init();
+    } else {
+        tracing_subscriber::registry()
+            .with(env_filter)
+            .with(file_layer)
+            .with(
+                fmt::layer()
+                    .with_writer(std::io::stderr)
+                    .with_ansi(false)
+                    .with_target(false)
+                    .with_thread_ids(false)
+                    .with_line_number(false),
+            )
+            .init();
+    }
 
     tracing::info!(
         user = %username,
@@ -123,11 +133,10 @@ pub fn init_server_logging<P: AsRef<Path>>(log_file: P) -> Result<tracing_append
         "Logging initialized"
     );
 
-    // Return the guard - caller MUST keep it alive!
     Ok(guard)
 }
 
-/// Initialize console-only logging (for commands other than serve)
+/// Initialize console-only logging (for commands other than serve).
 pub fn init_console_logging() {
     let env_filter = EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| EnvFilter::new("warn"));

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,7 +7,7 @@ use iroh::{
 };
 use n0_snafu::{Result, ResultExt};
 use std::sync::Arc;
-use std::io::Write as IoWrite;
+use std::io::{IsTerminal, Write as IoWrite};
 use std::path::Path;
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use crate::{ClientMessage, ServerMessage, ALPN};
@@ -110,140 +110,153 @@ pub async fn run_server(register_alias: Option<String>, session_path: Option<Str
     println!("Keys: [c]onnect | [s]end | [p]ull | [b]rowse | [r]elay | p[i]ng | Ctrl+C");
     println!("─────────────────────────────────────────────────────────────────\n");
 
-    // Enable raw mode for keyboard event handling
-    enable_raw_mode().unwrap_or_else(|err| eprintln!("Failed to enable raw mode: {err}"));
+    // When stdin is not a TTY (e.g. launched as a systemd service), skip all
+    // keyboard/clipboard interaction — the EventStream would spin on EOF and
+    // the raw-mode calls have no meaning without a terminal.
+    if std::io::stdin().is_terminal() {
+        // Enable raw mode for keyboard event handling
+        enable_raw_mode().unwrap_or_else(|err| eprintln!("Failed to enable raw mode: {err}"));
 
-    // Spawn task to handle keyboard events
-    let connect_clone = connect_command.clone();
-    let send_clone = send_command.clone();
-    let pull_clone = pull_command.clone();
-    let browse_clone = browse_command.clone();
-    let relay_clone = relay_command.clone();
-    let ping_clone = ping_command.clone();
+        // Spawn task to handle keyboard events
+        let connect_clone = connect_command.clone();
+        let send_clone = send_command.clone();
+        let pull_clone = pull_command.clone();
+        let browse_clone = browse_command.clone();
+        let relay_clone = relay_command.clone();
+        let ping_clone = ping_command.clone();
 
-    let keyboard_task = tokio::task::spawn(async move {
-        let mut event_stream = EventStream::new();
+        let keyboard_task = tokio::task::spawn(async move {
+            let mut event_stream = EventStream::new();
 
-        loop {
-            if let Some(event_result) = event_stream.next().await {
-                match event_result {
-                    Ok(Event::Key(key_event)) => {
-                        match (key_event.code, key_event.modifiers, key_event.kind) {
-                            // Handle 'c' key press to copy connect command
-                            (KeyCode::Char('c'), KeyModifiers::NONE, KeyEventKind::Press) => {
-                                match Clipboard::new() {
-                                    Ok(mut clipboard) => {
-                                        if clipboard.set_text(&connect_clone).is_ok() {
-                                            println!("\r\n✓ Connect command copied to clipboard!\r\n");
-                                        } else {
-                                            eprintln!("\r\n✗ Failed to copy to clipboard\r\n");
+            loop {
+                if let Some(event_result) = event_stream.next().await {
+                    match event_result {
+                        Ok(Event::Key(key_event)) => {
+                            match (key_event.code, key_event.modifiers, key_event.kind) {
+                                // Handle 'c' key press to copy connect command
+                                (KeyCode::Char('c'), KeyModifiers::NONE, KeyEventKind::Press) => {
+                                    match Clipboard::new() {
+                                        Ok(mut clipboard) => {
+                                            if clipboard.set_text(&connect_clone).is_ok() {
+                                                println!("\r\n✓ Connect command copied to clipboard!\r\n");
+                                            } else {
+                                                eprintln!("\r\n✗ Failed to copy to clipboard\r\n");
+                                            }
                                         }
-                                    }
-                                    Err(e) => {
-                                        eprintln!("\r\n✗ Failed to access clipboard: {}\r\n", e);
+                                        Err(e) => {
+                                            eprintln!("\r\n✗ Failed to access clipboard: {}\r\n", e);
+                                        }
                                     }
                                 }
-                            }
-                            // Handle 's' key press to copy send command
-                            (KeyCode::Char('s'), KeyModifiers::NONE, KeyEventKind::Press) => {
-                                match Clipboard::new() {
-                                    Ok(mut clipboard) => {
-                                        if clipboard.set_text(&send_clone).is_ok() {
-                                            println!("\r\n✓ Send command copied to clipboard!\r\n");
-                                        } else {
-                                            eprintln!("\r\n✗ Failed to copy to clipboard\r\n");
+                                // Handle 's' key press to copy send command
+                                (KeyCode::Char('s'), KeyModifiers::NONE, KeyEventKind::Press) => {
+                                    match Clipboard::new() {
+                                        Ok(mut clipboard) => {
+                                            if clipboard.set_text(&send_clone).is_ok() {
+                                                println!("\r\n✓ Send command copied to clipboard!\r\n");
+                                            } else {
+                                                eprintln!("\r\n✗ Failed to copy to clipboard\r\n");
+                                            }
                                         }
-                                    }
-                                    Err(e) => {
-                                        eprintln!("\r\n✗ Failed to access clipboard: {}\r\n", e);
+                                        Err(e) => {
+                                            eprintln!("\r\n✗ Failed to access clipboard: {}\r\n", e);
+                                        }
                                     }
                                 }
-                            }
-                            // Handle 'p' key press to copy pull command
-                            (KeyCode::Char('p'), KeyModifiers::NONE, KeyEventKind::Press) => {
-                                match Clipboard::new() {
-                                    Ok(mut clipboard) => {
-                                        if clipboard.set_text(&pull_clone).is_ok() {
-                                            println!("\r\n✓ Pull command copied to clipboard!\r\n");
-                                        } else {
-                                            eprintln!("\r\n✗ Failed to copy to clipboard\r\n");
+                                // Handle 'p' key press to copy pull command
+                                (KeyCode::Char('p'), KeyModifiers::NONE, KeyEventKind::Press) => {
+                                    match Clipboard::new() {
+                                        Ok(mut clipboard) => {
+                                            if clipboard.set_text(&pull_clone).is_ok() {
+                                                println!("\r\n✓ Pull command copied to clipboard!\r\n");
+                                            } else {
+                                                eprintln!("\r\n✗ Failed to copy to clipboard\r\n");
+                                            }
                                         }
-                                    }
-                                    Err(e) => {
-                                        eprintln!("\r\n✗ Failed to access clipboard: {}\r\n", e);
+                                        Err(e) => {
+                                            eprintln!("\r\n✗ Failed to access clipboard: {}\r\n", e);
+                                        }
                                     }
                                 }
-                            }
-                            // Handle 'b' key press to copy browse command
-                            (KeyCode::Char('b'), KeyModifiers::NONE, KeyEventKind::Press) => {
-                                match Clipboard::new() {
-                                    Ok(mut clipboard) => {
-                                        if clipboard.set_text(&browse_clone).is_ok() {
-                                            println!("\r\n✓ Browse command copied to clipboard!\r\n");
-                                        } else {
-                                            eprintln!("\r\n✗ Failed to copy to clipboard\r\n");
+                                // Handle 'b' key press to copy browse command
+                                (KeyCode::Char('b'), KeyModifiers::NONE, KeyEventKind::Press) => {
+                                    match Clipboard::new() {
+                                        Ok(mut clipboard) => {
+                                            if clipboard.set_text(&browse_clone).is_ok() {
+                                                println!("\r\n✓ Browse command copied to clipboard!\r\n");
+                                            } else {
+                                                eprintln!("\r\n✗ Failed to copy to clipboard\r\n");
+                                            }
                                         }
-                                    }
-                                    Err(e) => {
-                                        eprintln!("\r\n✗ Failed to access clipboard: {}\r\n", e);
+                                        Err(e) => {
+                                            eprintln!("\r\n✗ Failed to access clipboard: {}\r\n", e);
+                                        }
                                     }
                                 }
-                            }
-                            // Handle 'r' key press to copy relay command
-                            (KeyCode::Char('r'), KeyModifiers::NONE, KeyEventKind::Press) => {
-                                match Clipboard::new() {
-                                    Ok(mut clipboard) => {
-                                        if clipboard.set_text(&relay_clone).is_ok() {
-                                            println!("\r\n✓ Relay command copied to clipboard!\r\n");
+                                // Handle 'r' key press to copy relay command
+                                (KeyCode::Char('r'), KeyModifiers::NONE, KeyEventKind::Press) => {
+                                    match Clipboard::new() {
+                                        Ok(mut clipboard) => {
+                                            if clipboard.set_text(&relay_clone).is_ok() {
+                                                println!("\r\n✓ Relay command copied to clipboard!\r\n");
+                                            }
+                                            else {
+                                                eprintln!("\r\n✗ Failed to copy to clipboard\r\n");
+                                            }
                                         }
-                                        else {
-                                            eprintln!("\r\n✗ Failed to copy to clipboard\r\n");
+                                        Err(e) => {
+                                            eprintln!("\r\n✗ Failed to access clipboard: {}\r\n", e);
                                         }
-                                    }
-                                    Err(e) => {
-                                        eprintln!("\r\n✗ Failed to access clipboard: {}\r\n", e);
                                     }
                                 }
-                            }
-                            // Handle 'i' key press to copy ping command
-                            (KeyCode::Char('i'), KeyModifiers::NONE, KeyEventKind::Press) => {
-                                match Clipboard::new() {
-                                    Ok(mut clipboard) => {
-                                        if clipboard.set_text(&ping_clone).is_ok() {
-                                            println!("\r\n✓ Ping command copied to clipboard!\r\n");
-                                        } else {
-                                            eprintln!("\r\n✗ Failed to copy to clipboard\r\n");
+                                // Handle 'i' key press to copy ping command
+                                (KeyCode::Char('i'), KeyModifiers::NONE, KeyEventKind::Press) => {
+                                    match Clipboard::new() {
+                                        Ok(mut clipboard) => {
+                                            if clipboard.set_text(&ping_clone).is_ok() {
+                                                println!("\r\n✓ Ping command copied to clipboard!\r\n");
+                                            } else {
+                                                eprintln!("\r\n✗ Failed to copy to clipboard\r\n");
+                                            }
+                                        }
+                                        Err(e) => {
+                                            eprintln!("\r\n✗ Failed to access clipboard: {}\r\n", e);
                                         }
                                     }
-                                    Err(e) => {
-                                        eprintln!("\r\n✗ Failed to access clipboard: {}\r\n", e);
-                                    }
                                 }
+                                // Handle Ctrl+C to exit
+                                (KeyCode::Char('c'), KeyModifiers::CONTROL, KeyEventKind::Press) => {
+                                    break;
+                                }
+                                _ => {}
                             }
-                            // Handle Ctrl+C to exit
-                            (KeyCode::Char('c'), KeyModifiers::CONTROL, KeyEventKind::Press) => {
-                                break;
-                            }
-                            _ => {}
                         }
+                        Err(e) => {
+                            eprintln!("Failed to process event: {}", e);
+                        }
+                        _ => {}
                     }
-                    Err(e) => {
-                        eprintln!("Failed to process event: {}", e);
-                    }
-                    _ => {}
                 }
             }
-        }
-    });
+        });
 
-    // Wait for either Ctrl+C signal or keyboard task to complete
-    tokio::select! {
-        _ = tokio::signal::ctrl_c() => {
-            println!("\r\nShutting down...");
+        // Wait for either Ctrl+C signal or keyboard task to complete
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                println!("\r\nShutting down...");
+            }
+            _ = keyboard_task => {
+                println!("\r\nShutting down...");
+            }
         }
-        _ = keyboard_task => {
-            println!("\r\nShutting down...");
-        }
+
+        disable_raw_mode().unwrap_or_else(|e| eprintln!("Failed to disable raw mode: {}", e));
+    } else {
+        // Headless mode (no TTY): running as a systemd service or piped process.
+        // Just wait for SIGINT; keyboard shortcuts are not available.
+        tracing::info!(pid = std::process::id(), "Running headless — waiting for SIGINT to stop");
+        tokio::signal::ctrl_c().await.ok();
+        println!("Shutting down...");
     }
 
     // Unregister from backend if we registered
@@ -257,9 +270,6 @@ pub async fn run_server(register_alias: Option<String>, session_path: Option<Str
             }
         }
     }
-
-    // Disable raw mode before exiting
-    disable_raw_mode().unwrap_or_else(|e| eprintln!("Failed to disable raw mode: {}", e));
 
     // Shutdown the router
     router.shutdown().await.e()?;


### PR DESCRIPTION
- scripts/install-service.sh: registers `kerr serve --register <alias>` as
  a systemd user service; checks for a valid login session before writing
  the unit file, reads the alias from ~/.config/kerr/autostart.json (key
  "register") or --name CLI arg, and errors out with clear messages when
  either precondition is unmet; enables loginctl linger so the service
  starts at boot without an interactive login.
- scripts/uninstall-service.sh: stops, disables, and removes the unit file.
- src/server.rs: detect non-TTY stdin (IsTerminal) and skip raw-mode +
  EventStream keyboard loop when running headless (e.g. as a systemd
  service); in that case only tokio::signal::ctrl_c() is awaited, which
  means the server no longer exits immediately or spins the CPU on EOF.

https://claude.ai/code/session_01D7CyxL5dRaWvyCSkAo8PDS